### PR TITLE
Fixed errant ';'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ install: $(TARGET) $(HEADER) $(PC_FILE)
 	@install -D -m 0755 $(TARGET) $(abspath $(DESTDIR)/$(LIBDIR)/$(TARGET))
 	@echo "Installing $(HEADER)"
 	@install -D -m 0644 $(HEADER) $(abspath $(DESTDIR)/$(INCLUDEDIR)/$(HEADER))
-	@if [ "$(CHECK_LIBPNG)" != "error" ]; then ;\
+	@if [ "$(CHECK_LIBPNG)" != "error" ]; then \
 		echo "Installing $(HEADER_LIBPNG)" ;\
 		install -D -m 0644 $(HEADER_LIBPNG) $(abspath $(DESTDIR)/$(INCLUDEDIR)/$(HEADER_LIBPNG)) ;\
 	fi


### PR DESCRIPTION
Was getting:

[nix-shell:~/projects/identicon-c]$ make PREFIX=/tmp installInstalling libidenticon-c.so.0.0.0
Installing identicon-c.h
/bin/sh: -c: line 1: syntax error near unexpected token `;'
/bin/sh: -c: line 1: `	echo "Installing identicon-c_libpng.h" ;\'
make: *** [Makefile:118: install] Error 1

Now fixed.